### PR TITLE
Allow custom exception handling

### DIFF
--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -1,13 +1,29 @@
 from distutils.version import StrictVersion
 
 import rest_framework
+from rest_framework import status
 from rest_framework import serializers
 from django.forms import widgets
+from rest_framework.exceptions import APIException
+
+
+class ValidationError(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+
+    def __init__(self, detail):
+        self.detail = detail
+
+    def __str__(self):
+        return self.detail
 
 
 if StrictVersion(rest_framework.VERSION) < StrictVersion('3.0.0'):
     class Serializer(serializers.Serializer):
-        pass
+        def is_valid(self, raise_exception=False):
+            if self.errors and raise_exception:
+                raise ValidationError(self.errors)
+
+            return not self.errors
 
     class PasswordField(serializers.CharField):
         widget = widgets.PasswordInput

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -1,5 +1,4 @@
 from rest_framework.views import APIView
-from rest_framework import status
 from rest_framework.response import Response
 
 from .settings import api_settings
@@ -56,12 +55,12 @@ class JSONWebTokenAPIView(APIView):
             data=get_request_data(request)
         )
 
-        serializer.is_valid(raise_exception=True)
-        user = serializer.object.get('user') or request.user
-        token = serializer.object.get('token')
-        response_data = jwt_response_payload_handler(token, user, request)
+        if serializer.is_valid(raise_exception=True):
+            user = serializer.object.get('user') or request.user
+            token = serializer.object.get('token')
+            response_data = jwt_response_payload_handler(token, user, request)
 
-        return Response(response_data)
+            return Response(response_data)
 
 
 class ObtainJSONWebToken(JSONWebTokenAPIView):

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -55,12 +55,12 @@ class JSONWebTokenAPIView(APIView):
             data=get_request_data(request)
         )
 
-        if serializer.is_valid(raise_exception=True):
-            user = serializer.object.get('user') or request.user
-            token = serializer.object.get('token')
-            response_data = jwt_response_payload_handler(token, user, request)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.object.get('user') or request.user
+        token = serializer.object.get('token')
+        response_data = jwt_response_payload_handler(token, user, request)
 
-            return Response(response_data)
+        return Response(response_data)
 
 
 class ObtainJSONWebToken(JSONWebTokenAPIView):

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -56,14 +56,12 @@ class JSONWebTokenAPIView(APIView):
             data=get_request_data(request)
         )
 
-        if serializer.is_valid():
-            user = serializer.object.get('user') or request.user
-            token = serializer.object.get('token')
-            response_data = jwt_response_payload_handler(token, user, request)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.object.get('user') or request.user
+        token = serializer.object.get('token')
+        response_data = jwt_response_payload_handler(token, user, request)
 
-            return Response(response_data)
-
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return Response(response_data)
 
 
 class ObtainJSONWebToken(JSONWebTokenAPIView):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -263,7 +263,8 @@ class VerifyJSONWebTokenTests(TokenTestCase):
         response = client.post('/auth-token-verify/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertRegexpMatches(response.data['non_field_errors'][0],
+        self.assertRegexpMatches(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                                 response.data['non_field_errors'][0],
                                  'Signature has expired')
 
     def test_verify_jwt_fails_with_bad_token(self):
@@ -277,7 +278,8 @@ class VerifyJSONWebTokenTests(TokenTestCase):
         response = client.post('/auth-token-verify/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertRegexpMatches(response.data['non_field_errors'][0],
+        self.assertRegexpMatches(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                                 response.data['non_field_errors'][0],
                                  'Error decoding signature')
 
     def test_verify_jwt_fails_with_missing_user(self):
@@ -296,7 +298,8 @@ class VerifyJSONWebTokenTests(TokenTestCase):
         response = client.post('/auth-token-verify/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertRegexpMatches(response.data['non_field_errors'][0],
+        self.assertRegexpMatches(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                                 response.data['non_field_errors'][0],
                                  "User doesn't exist")
 
 
@@ -353,7 +356,8 @@ class RefreshJSONWebTokenTests(TokenTestCase):
         response = client.post('/auth-token-refresh/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'][0],
+        self.assertEqual(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                         response.data['non_field_errors'][0],
                          'Refresh has expired.')
 
     def tearDown(self):


### PR DESCRIPTION
Without the `serializer.is_valid (raise_exception = True)` the custom exception handler is ignored.
