### PR TITLE
Allow custom exception handling

### DIFF
--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -1,12 +1,29 @@
 from django.contrib.auth import get_user_model
 
+import rest_framework
+from rest_framework import status
 from rest_framework import serializers
+from django.forms import widgets
+from rest_framework.exceptions import APIException
 
 
-class Serializer(serializers.Serializer):
-    @property
-    def object(self):
-        return self.validated_data
+class ValidationError(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+
+    def __init__(self, detail):
+        self.detail = detail
+
+    def __str__(self):
+        return self.detail
+
+
+if StrictVersion(rest_framework.VERSION) < StrictVersion('3.0.0'):
+    class Serializer(serializers.Serializer):
+        def is_valid(self, raise_exception=False):
+            if self.errors and raise_exception:
+                raise ValidationError(self.errors)
+
+            return not self.errors
 
 
 class PasswordField(serializers.CharField):

--- a/rest_framework_jwt/compat.py
+++ b/rest_framework_jwt/compat.py
@@ -6,6 +6,8 @@ from rest_framework import serializers
 from django.forms import widgets
 from rest_framework.exceptions import APIException
 
+from distutils.version import StrictVersion
+
 
 class ValidationError(APIException):
     status_code = status.HTTP_400_BAD_REQUEST

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -1,5 +1,4 @@
 from rest_framework.views import APIView
-from rest_framework import status
 from rest_framework.response import Response
 from datetime import datetime
 
@@ -54,12 +53,12 @@ class JSONWebTokenAPIView(APIView):
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
 
-        serializer.is_valid(raise_exception=True)
-        user = serializer.object.get('user') or request.user
-        token = serializer.object.get('token')
-        response_data = jwt_response_payload_handler(token, user, request)
+        if serializer.is_valid(raise_exception=True):
+            user = serializer.object.get('user') or request.user
+            token = serializer.object.get('token')
+            response_data = jwt_response_payload_handler(token, user, request)
 
-        return Response(response_data)
+            return Response(response_data)
 
 
 class ObtainJSONWebToken(JSONWebTokenAPIView):

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -54,21 +54,12 @@ class JSONWebTokenAPIView(APIView):
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
 
-        if serializer.is_valid():
-            user = serializer.object.get('user') or request.user
-            token = serializer.object.get('token')
-            response_data = jwt_response_payload_handler(token, user, request)
-            response = Response(response_data)
-            if api_settings.JWT_AUTH_COOKIE:
-                expiration = (datetime.utcnow() +
-                              api_settings.JWT_EXPIRATION_DELTA)
-                response.set_cookie(api_settings.JWT_AUTH_COOKIE,
-                                    token,
-                                    expires=expiration,
-                                    httponly=True)
-            return response
+        serializer.is_valid(raise_exception=True)
+        user = serializer.object.get('user') or request.user
+        token = serializer.object.get('token')
+        response_data = jwt_response_payload_handler(token, user, request)
 
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return Response(response_data)
 
 
 class ObtainJSONWebToken(JSONWebTokenAPIView):

--- a/rest_framework_jwt/views.py
+++ b/rest_framework_jwt/views.py
@@ -53,12 +53,12 @@ class JSONWebTokenAPIView(APIView):
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
 
-        if serializer.is_valid(raise_exception=True):
-            user = serializer.object.get('user') or request.user
-            token = serializer.object.get('token')
-            response_data = jwt_response_payload_handler(token, user, request)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.object.get('user') or request.user
+        token = serializer.object.get('token')
+        response_data = jwt_response_payload_handler(token, user, request)
 
-            return Response(response_data)
+        return Response(response_data)
 
 
 class ObtainJSONWebToken(JSONWebTokenAPIView):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -299,7 +299,8 @@ class VerifyJSONWebTokenTestsSymmetric(TokenTestCase):
         response = client.post('/auth-token-verify/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertRegexpMatches(response.data['non_field_errors'][0],
+        self.assertRegexpMatches(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                                 response.data['non_field_errors'][0],
                                  'Signature has expired')
 
     def test_verify_jwt_fails_with_bad_token(self):
@@ -313,7 +314,8 @@ class VerifyJSONWebTokenTestsSymmetric(TokenTestCase):
         response = client.post('/auth-token-verify/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertRegexpMatches(response.data['non_field_errors'][0],
+        self.assertRegexpMatches(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                                 response.data['non_field_errors'][0],
                                  'Error decoding signature')
 
     def test_verify_jwt_fails_with_missing_user(self):
@@ -332,7 +334,8 @@ class VerifyJSONWebTokenTestsSymmetric(TokenTestCase):
         response = client.post('/auth-token-verify/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertRegexpMatches(response.data['non_field_errors'][0],
+        self.assertRegexpMatches(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                                 response.data['non_field_errors'][0],
                                  "User doesn't exist")
 
 
@@ -486,7 +489,8 @@ class RefreshJSONWebTokenTests(TokenTestCase):
         response = client.post('/auth-token-refresh/', {'token': token},
                                format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data['non_field_errors'][0],
+        self.assertEqual(response.data['detail']['non_field_errors'][0] if 'detail' in response.data else
+                         response.data['non_field_errors'][0],
                          'Refresh has expired.')
 
     def tearDown(self):


### PR DESCRIPTION
Hi everyone,

As requested, I'm submitting again this pull request - you can see the original pull request [here](https://github.com/GetBlimp/django-rest-framework-jwt/pull/210).

Problem: Without the serializer.is_valid (raise_exception = True) the custom exception handler is ignored.


