### PR TITLE
Update README.rst with the new documentation URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Full documentation for the project is available at `docs`_.
 
 You may also want to follow the `author`_ on Twitter.
 
-.. _docs: http://getblimp.github.io/django-rest-framework-jwt
+.. _docs: https://jpadilla.github.io/django-rest-framework-jwt/
 .. _JSON Web Token Authentication: http://tools.ietf.org/html/draft-ietf-oauth-json-web-token
 .. _Django REST framework: http://django-rest-framework.org/
 .. _Video: https://www.youtube.com/watch?v=825hodQ61bg


### PR DESCRIPTION
I was going through your README file and I noticed that the documentation link is outdated and it leads to a site that doesn't exist while the documentation of the module exists in another link, i.e. https://jpadilla.github.io/django-rest-framework-jwt/. I figured it needed to have the documentation link changed to the new one so that developers who would want to use this module wouldn't have to be lost on where the documentation really is, hence why I made a pull request.